### PR TITLE
Add visit count tracking

### DIFF
--- a/src/theme/Layout/index.js
+++ b/src/theme/Layout/index.js
@@ -1,0 +1,29 @@
+import React from 'react';
+import Layout from '@theme-original/Layout';
+import { useLocation } from '@docusaurus/router';
+
+export default function LayoutWrapper(props) {
+  const { pathname } = useLocation();
+  const safePath = pathname === '/' ? 'root' : pathname;
+  const pixelUrl = `https://waldolemmer.goatcounter.com/count?p=${encodeURIComponent(safePath)}`;
+
+  return (
+    <Layout {...props}>
+      {props.children}
+
+      <img
+        src={pixelUrl}
+        style={{ width: 0, height: 0, border: 0, display: 'none' }}
+        alt=""
+      />
+
+      <noscript>
+        <img
+          src={pixelUrl}
+          style={{ width: 0, height: 0, border: 0, display: 'none' }}
+          alt=""
+        />
+      </noscript>
+    </Layout>
+  );
+}


### PR DESCRIPTION
Use pixel-tracking to collect visit counts at GoatCounter (which claims to not collect any user data: https://www.arp242.net/dnt.html).

> But, this is not what GoatCounter does, it just collects some basic statistics about how many people visit your site. To give a real-world analogy: it just counts how many people are entering your shop through which door. What it doesn’t do is then follow those people after they’ve left your store to see which other stores they visit, snoop on as much personal details as possible, and create a profile based on that. That’s what tracking is, and is just not the same thing as what GoatCounter is doing.